### PR TITLE
[#48] Fix grpc-web outputs format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Build stub codes
         run: |
-          protoc -Isrc/main/proto/ --js_out=import_style=commonjs,binary:. --grpc-web_out=import_style=typescript,mode=grpcwebtext:. $(find src/main/proto -iname "*.proto")
+          protoc -Isrc/main/proto/ --js_out=import_style=commonjs,binary:. --grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext:. $(find src/main/proto -iname "*.proto")
 
 
   check-buildable-for-csharp:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Build stub codes
         run: |
-          protoc -Isrc/main/proto/ --js_out=import_style=commonjs,binary:. --grpc-web_out=import_style=typescript,mode=grpcwebtext:. $(find src/main/proto -iname "*.proto")
+          protoc -Isrc/main/proto/ --js_out=import_style=commonjs,binary:. --grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext:. $(find src/main/proto -iname "*.proto")
 
       - name: Publish to NPM Repository
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "wedding.kanshasai"
-version = "0.0.1"
+version = "0.0.2"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## About
nextjsで扱えるように出力形式を`typescript`から`commonjs+dts`に変更しました。

## Reference
- Close #48 
